### PR TITLE
Don't link to sapp-jsutils when we don't need to

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ Plugin for macro-, mini-quad (quads) to do anything with url.
 """
 readme="README.md"
 
-[dependencies]
+[target.'cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos", target_os = "android")))'.dependencies]
 sapp-jsutils = "0.1.4"
 
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "macos", target_os = "android"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ Plugin for macro-, mini-quad (quads) to do anything with url.
 """
 readme="README.md"
 
-[target.'cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos", target_os = "android")))'.dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 sapp-jsutils = "0.1.4"
 
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "macos", target_os = "android"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,12 @@
 //! ```
 //! Done! Now you can use this crate.
 
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "android"
+)))]
 #[allow(unused_imports)]
 use sapp_jsutils::{JsObject, JsObjectWeak};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,7 @@
 //! ```
 //! Done! Now you can use this crate.
 
-#[cfg(not(any(
-    target_os = "linux",
-    target_os = "windows",
-    target_os = "macos",
-    target_os = "android"
-)))]
-#[allow(unused_imports)]
+#[cfg(target_arch = "wasm32")]
 use sapp_jsutils::{JsObject, JsObjectWeak};
 
 #[no_mangle]


### PR DESCRIPTION
Currently sapp_jsutils is always a dependency, whether compiling for WASM or not. Unfortunately when compiling using `codegen-units = 1`, this causes a bunch of unlinked external symbols (at least for me on Windows.) This PR just ensures `sapp_jsutils` is never a dependency at the same time as `webbrowser`, and cfg-gates the import in `lib.rs` accordingly.