### PR TITLE
Bump `webbrowser` version to fix security issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme="README.md"
 sapp-jsutils = "0.1.4"
 
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "macos", target_os = "android"))'.dependencies]
-webbrowser = "0.5.5"
+webbrowser = "0.8.8"
 
 [dev-dependencies]
 egui-macroquad = "0.1.0"


### PR DESCRIPTION
Update to any version above 0.8.3 fixes the issue. Advisory: https://github.com/advisories/GHSA-m589-mv4q-p7rj

Only method used is `webbrowser::open` and the API did not change.